### PR TITLE
Work-around for zerolog v1.32.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/phsym/zeroslog
 
 go 1.21
 
-require github.com/rs/zerolog v1.31.0
+require github.com/rs/zerolog v1.32.0
 
 require (
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.31.0 h1:FcTR3NnLWW+NnTwwhFWiJSZr4ECLpqCm6QsEnyvbV4A=
 github.com/rs/zerolog v1.31.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
+github.com/rs/zerolog v1.32.0 h1:keLypqrlIjaFsbmJOBdB/qvyF8KEtCWHwobLp5l/mQ0=
+github.com/rs/zerolog v1.32.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=


### PR DESCRIPTION
The change in `zerolog v1.32.0` that breaks things appears to be:
```
  // should returns true if the log event should be logged.
  func (l *Logger) should(lvl Level) bool {
+ 	if l.w == nil {
+ 		return false
+ 	}
	if lvl < l.level || lvl < GlobalLevel() {
		return false
	}
```

which is called a couple of stack frames below:
```
evt := l.Log()
```
which is present in at least two places in `zeroslog` code. Up until this change, passing in blank `zerolog.Context` objects worked fine. Now it is necessary to pass in a proper logger inside of the `zerolog.Context` object so that the non-`nil` check for the logger's `io.Writer` shown above will not fail.

Sadly the `l` (i.e. logger) field within `zerolog.Context` is private and there is no public function provided within the `zerolog` code base to set it. The only way I could find to return a new context object is to use `zerolog.Logger.With()`. However, that function manipulates a further private field in the `zerolog.Logger` object named `context`,[^1] an array of `byte`. This field is used to pre-format attributes for output via `zerolog.Logger.WithAttrs()` or `zerolog.Logger.WithGroup()` to speed up output. Using a previously modified `zerolog.Logger` object to generate the required `zerolog.Context` object cascades any previously changes made to the logger object down to the "new" logger within the returned context object.

The only way I could work around all of the above was to capture the root logger object in both `zeroslog.Handler` and `zeroslog.groupHandler`. The `root` field in both places is used with `With()` to create the new context with the root logger. Any changes made to that logger (added to that logger's internal `context` field) will thus be done to a "clean" logger and will not percolate to more embedded "with" objects. The `With()` method is used against a `Logger` object, not a pointer, so the root is not itself changed AFAIK.

Short of changes to the `zerolog` code this is the best I could think of. I'm not 100% sure I got it right but it's passing tests now so I'm pushing the PR for evaluation and critique.

[^1]: Note that this is unfortunate naming as it is unrelated to either `zerolog.Context` or `context.Context`. This is made clear (or further obfuscated, if you will) in the code for [`zerolog.Logger.With()`](https://github.com/rs/zerolog/blob/master/log.go#L279) as well as the declaration of [`zerolog.Logger`](https://github.com/rs/zerolog/blob/master/log.go#L229) wherein both `context` and `ctx` are used as field names, the latter referring to `context.Context`.
