### PR TITLE
Use go.mod exclude statement to block upgrade to rs/zerolog v1.32.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,7 @@ require (
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 )
+
+// This version of rs/zerolog breaks phsym/zeroslog
+exclude github.com/rs/zerolog v1.32.0
+


### PR DESCRIPTION
This seems to prevent `phsym/zeroslog` from updating to the `rs/zerolog` that breaks `zeroslog`. It might be a useful fix to make until some more permanent solution is found.