### PR TITLE
Use proposed new zerolog function to fix breakage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,7 @@ module github.com/phsym/zeroslog
 
 go 1.21
 
-require (
-	github.com/rs/zerolog v1.32.0
-)
-
-replace github.com/rs/zerolog => /home/marc/work/go/src/github.com/madkins23/zerolog
+require github.com/rs/zerolog v1.32.1-0.20240306065720-74cf37a3965b
 
 require (
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/phsym/zeroslog
 
 go 1.21
 
-require github.com/rs/zerolog v1.32.1-0.20240306065720-74cf37a3965b
+require github.com/rs/zerolog v1.33.0
 
 require (
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,14 +2,14 @@ module github.com/phsym/zeroslog
 
 go 1.21
 
-require github.com/rs/zerolog v1.31.0
+require (
+	github.com/rs/zerolog v1.32.0
+)
+
+replace github.com/rs/zerolog => /home/marc/work/go/src/github.com/madkins23/zerolog
 
 require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 )
-
-// This version of rs/zerolog breaks phsym/zeroslog
-exclude github.com/rs/zerolog v1.32.0
-

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,5 @@
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/madkins23/zerolog v0.0.0-20240204145057-bd2896587dac/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -8,10 +7,8 @@ github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APP
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
-github.com/rs/zerolog v1.31.0 h1:FcTR3NnLWW+NnTwwhFWiJSZr4ECLpqCm6QsEnyvbV4A=
-github.com/rs/zerolog v1.31.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
-github.com/rs/zerolog v1.32.0 h1:keLypqrlIjaFsbmJOBdB/qvyF8KEtCWHwobLp5l/mQ0=
-github.com/rs/zerolog v1.32.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
+github.com/rs/zerolog v1.32.1-0.20240306065720-74cf37a3965b h1:eUxavk8hnzV7Kt3bnsnjOUyBjLSaiS1OCocMJKXO9+M=
+github.com/rs/zerolog v1.32.1-0.20240306065720-74cf37a3965b/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/madkins23/zerolog v0.0.0-20240204145057-bd2896587dac/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -9,6 +10,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.31.0 h1:FcTR3NnLWW+NnTwwhFWiJSZr4ECLpqCm6QsEnyvbV4A=
 github.com/rs/zerolog v1.31.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
+github.com/rs/zerolog v1.32.0 h1:keLypqrlIjaFsbmJOBdB/qvyF8KEtCWHwobLp5l/mQ0=
+github.com/rs/zerolog v1.32.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APP
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
-github.com/rs/zerolog v1.32.1-0.20240306065720-74cf37a3965b h1:eUxavk8hnzV7Kt3bnsnjOUyBjLSaiS1OCocMJKXO9+M=
-github.com/rs/zerolog v1.32.1-0.20240306065720-74cf37a3965b/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
+github.com/rs/zerolog v1.33.0 h1:1cU2KZkvPxNyfgEmhHAz/1A9Bz+llsdYzklWFzgp0r8=
+github.com/rs/zerolog v1.33.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=

--- a/zerolog.go
+++ b/zerolog.go
@@ -131,7 +131,7 @@ func (h *Handler) Handle(_ context.Context, rec slog.Record) error {
 func (h *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	return &Handler{
 		opts:   h.opts,
-		logger: mapAttrs(zerolog.NewContextWithResetLogger(h.logger), attrs...).Logger(),
+		logger: mapAttrs(h.logger.With().Reset(), attrs...).Logger(),
 	}
 }
 
@@ -139,7 +139,7 @@ func (h *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
 func (h *Handler) WithGroup(name string) slog.Handler {
 	return &groupHandler{
 		parent: h,
-		ctx:    zerolog.NewContextWithResetLogger(h.logger),
+		ctx:    h.logger.With().Reset(),
 		name:   strings.TrimSpace(name),
 	}
 }
@@ -182,7 +182,7 @@ func (h *groupHandler) Handle(ctx context.Context, rec slog.Record) error {
 func (h *groupHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	return &groupHandler{
 		parent: h.parent,
-		ctx:    mapAttrs(zerolog.NewContextWithResetLogger(h.ctx.Logger()), attrs...),
+		ctx:    mapAttrs(h.ctx.Logger().With().Reset(), attrs...),
 		name:   h.name,
 	}
 }
@@ -191,7 +191,7 @@ func (h *groupHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 func (h *groupHandler) WithGroup(name string) slog.Handler {
 	return &groupHandler{
 		parent: h,
-		ctx:    zerolog.NewContextWithResetLogger(h.ctx.Logger()),
+		ctx:    h.ctx.Logger().With().Reset(),
 		name:   name,
 	}
 }

--- a/zerolog.go
+++ b/zerolog.go
@@ -131,7 +131,7 @@ func (h *Handler) Handle(_ context.Context, rec slog.Record) error {
 func (h *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	return &Handler{
 		opts:   h.opts,
-		logger: mapAttrs(h.logger.With(), attrs...).Logger(),
+		logger: mapAttrs(zerolog.NewContextWithResetLogger(h.logger), attrs...).Logger(),
 	}
 }
 
@@ -139,7 +139,7 @@ func (h *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
 func (h *Handler) WithGroup(name string) slog.Handler {
 	return &groupHandler{
 		parent: h,
-		ctx:    zerolog.Context{},
+		ctx:    zerolog.NewContextWithResetLogger(h.logger),
 		name:   strings.TrimSpace(name),
 	}
 }
@@ -182,7 +182,7 @@ func (h *groupHandler) Handle(ctx context.Context, rec slog.Record) error {
 func (h *groupHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	return &groupHandler{
 		parent: h.parent,
-		ctx:    mapAttrs(h.ctx.Logger().With(), attrs...),
+		ctx:    mapAttrs(zerolog.NewContextWithResetLogger(h.ctx.Logger()), attrs...),
 		name:   h.name,
 	}
 }
@@ -191,7 +191,7 @@ func (h *groupHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 func (h *groupHandler) WithGroup(name string) slog.Handler {
 	return &groupHandler{
 		parent: h,
-		ctx:    zerolog.Context{},
+		ctx:    zerolog.NewContextWithResetLogger(h.ctx.Logger()),
 		name:   name,
 	}
 }

--- a/zerolog.go
+++ b/zerolog.go
@@ -131,7 +131,7 @@ func (h *Handler) Handle(_ context.Context, rec slog.Record) error {
 func (h *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	return &Handler{
 		opts:   h.opts,
-		logger: mapAttrs(h.logger.With().Reset(), attrs...).Logger(),
+		logger: mapAttrs(h.logger.With(), attrs...).Logger(),
 	}
 }
 


### PR DESCRIPTION
This is a proposed fix for the `rs/zerolog v1.32.0` breakage. It depends on a change to the `rs/zerolog` code that I have yet to file, the addition of a single function:

```go
func NewContextWithResetLogger(l Logger) Context {
    l.context = enc.AppendBeginMarker(make([]byte, 0, 500))
    return Context{l: l}
}
```

**More detail**

[My previous PR](https://github.com/phsym/zeroslog/pull/4) used `zerolog.Logger.With` to generate a new `zerolog.Context` object because there was no other way to generate one with a specific logger. This would be replaced by `NewContextWithResetLogger`. In addition, in my previous PR I had to plumb a "root" logger through so that the `With` method wouldn't generate a context with predefined fields. In this case the first line of `NewContextWithResetLogger` replaces any predefined fields with a single `{` character via `enc.AppendBeginMarke`).

**Next Steps**

If we're both satisfied with this I can file a PR on `rs/zerolog` to create `NewContextWithResetLogger` (or something like that). I also wanted to have this PR ready so that I can refer to it when I file that PR.

In the meantime, if you want to test this:

1. `git clone` both (examples use `ssh`):
    - [`madkins23/zerolog`](https://github.com/madkins23/zerolog)  
      `git clone -b fix-zerolog git@github.com:madkins23/zerolog`
    - [`madkins23/zeroslog`](https://github.com/madkins23/zeroslog)
      `git clone -b fix-zerolog git@github.com:madkins23/zeroslog`
2. Edit `github.com/madkins23/zeroslog/go.mod`:
    - In the `replace` line change the path to my clone of `madkins23/zerolog`
      to the location of your clone of that repository in step 1.
3.  Run `go test ./...` in the `madkins/zeroslog` clone directory.

If you want to verify that you're using the right version of `zerolog` you can edit file `github.com/madkins23/ctx.go` and add a `fmt.Println` to the beginning of the `init` function.

I've also used a similar mechanism to pull all of this into my [benchmark/verification test harness](https://github.com/madkins23/go-slog), which has a bunch of specific tests. No errors there either.

As a side note, I'm mortified that I didn't now how to use the `replace` line in `go.mod` until now. Would have saved me some amount of work over the last few years.  :disappointed: 
