### PR TITLE
Message key should be slog.MessageKey = "msg"

### DIFF
--- a/zerolog.go
+++ b/zerolog.go
@@ -49,13 +49,14 @@ var _ zerologHandler = (*Handler)(nil)
 // NewHandler creates a *ZerologHandler implementing slog.Handler.
 // It wraps a zerolog.Logger to which log records will be sent.
 //
-// Unlesse opts.Level is not nil, the logger level is used to filter out records, otherwise
+// Unless opts.Level is not nil, the logger level is used to filter out records, otherwise
 // opts.Level is used.
 //
 // The provided logger instance must be configured to not send timestamps or caller information.
 //
 // If opts is nil, it assumes default options values.
 func NewHandler(logger zerolog.Logger, opts *HandlerOptions) *Handler {
+	zerolog.MessageFieldName = slog.MessageKey
 	if opts == nil {
 		opts = new(HandlerOptions)
 	}

--- a/zerolog_test.go
+++ b/zerolog_test.go
@@ -235,6 +235,10 @@ func TestZerolog_Group(t *testing.T) {
 	}
 }
 
+// TestZerolog_MessageKey checks to see if the logged message key is slog.MessageKey.
+// The field name of the message key should be the value of slog.MessageKey = "msg".
+//   - Constant values are defined for slog/log
+//   - Field values are defined for the JSONHandler.Handle() implementation
 func TestZerolog_MessageKey(t *testing.T) {
 	out := bytes.Buffer{}
 	hdl := NewJsonHandler(&out, nil)

--- a/zerolog_test.go
+++ b/zerolog_test.go
@@ -235,6 +235,23 @@ func TestZerolog_Group(t *testing.T) {
 	}
 }
 
+func TestZerolog_MessageKey(t *testing.T) {
+	out := bytes.Buffer{}
+	hdl := NewJsonHandler(&out, nil)
+	_ = hdl.Handle(context.Background(), slog.NewRecord(time.Now(), slog.LevelInfo, "foobar", 0))
+	m := map[string]any{}
+	if err := json.NewDecoder(&out).Decode(&m); err != nil {
+		t.Fatalf("Failed to json decode log output: %s", err.Error())
+	}
+	if _, found := m[slog.MessageKey]; !found {
+		if _, found := m["message"]; found {
+			t.Fatalf("Found 'message' key instead of '%s'", slog.MessageKey)
+		} else {
+			t.Fatalf("No '%s' key", slog.MessageKey)
+		}
+	}
+}
+
 func TestZerolog_AddSource(t *testing.T) {
 	out := bytes.Buffer{}
 	hdl := NewJsonHandler(&out, &HandlerOptions{AddSource: true})


### PR DESCRIPTION
Justification for this change is that:

* there is a defined and documented constant `slog.MessageKey` and
* this is what `JSONHandler` does.

So a little thin on this one. Could be a problem if field names changed for existing users. Maybe needs a configuration option.
